### PR TITLE
Fix segfault in -O1 or higher in tppmktop

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -11,7 +11,7 @@
             ],
             "compilerPath": "/usr/bin/gcc",
             "cStandard": "c17",
-            "cppStandard": "gnu++14",
+            "cppStandard": "c++14",
             "intelliSenseMode": "linux-gcc-x64",
             "configurationProvider": "ms-vscode.makefile-tools"
         }

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ else
 AM_CFLAGS = -O3
 AM_CXXFLAGS = -O3
 endif
-AM_CXXFLAGS += -std=c++11
+AM_CXXFLAGS += -std=c++14
 SUBDIRS = src
 #AM_CPPFLAGS = -I$(PWD)/include 
 dist_doc_DATA = README

--- a/include/async_call.hpp
+++ b/include/async_call.hpp
@@ -20,7 +20,8 @@ namespace tpp {
     auto future = std::async(std::launch::async, f, x...);
     if (future.wait_for(std::chrono::seconds(timeout)) == std::future_status::timeout) {
       TPPE << boost::format(" << Timeout %d failed! >>") % timeout; // TPP log entry will be placed here
-      std::terminate();
+      // std::terminate();
+      throw std::runtime_error("Timeout occurred");
     }
     std::clock_t en = std::clock();
     TPPD << boost::format(" << Asynchronous call finished in %.3f sec. >>") % ((double)(en - beg) / CLOCKS_PER_SEC);

--- a/include/atom_definer.hpp
+++ b/include/atom_definer.hpp
@@ -186,6 +186,11 @@ namespace tpp {
                   const AtomDefiner::Settings&,
                   Topology &);
 
+      /** \brief Now this function is not overriden.
+        * See parent function for details.
+        */
+      bool connectDB() override;
+
       /** \brief Print current scores into log-file
         */
       void logScores();
@@ -269,11 +274,6 @@ namespace tpp {
 
     protected:
       AtomMapper atom_mapper; //!< map of atomtypes loaded completely from DB
-
-      /** \brief Now this function is not overriden.
-        * See parent function for details.
-        */
-      virtual bool connectDB();
 
       /** \brief Prints useful information about SMART fit procedure results.
         *

--- a/include/bond_definer.hpp
+++ b/include/bond_definer.hpp
@@ -26,6 +26,8 @@ namespace tpp {
       ~BondDefiner();
       void bondAlign();
       void log_needed_bonds();
+      // methods
+      bool connectDB() override;
 
     private:
       BondDefiner::Settings bondSettings;
@@ -37,8 +39,6 @@ namespace tpp {
 
       bool verbose;
 
-      // methods
-      bool connectDB() override;
 
       /** \brief Complete bonds exploiting DB definitions.
         */

--- a/include/db_base.hpp
+++ b/include/db_base.hpp
@@ -52,14 +52,15 @@ namespace tpp {
         */
       virtual ~DbBase();
 
-    protected:
-      Settings settings;         //!< Structure with DB connection settings
-      mysqlpp::Connection *con;  //!< Pointer to Connection object
-
       /** \brief Connect to database.
         *  Method is called from the constructor.
         */
       virtual bool connectDB();
+
+    protected:
+      Settings settings;         //!< Structure with DB connection settings
+      mysqlpp::Connection *con;  //!< Pointer to Connection object
+
   };
 
   /**
@@ -68,11 +69,6 @@ namespace tpp {
   class DbInfo: public DbBase {
 
     protected:
-      /** \brief Overriden method of DB connection.
-        *
-        * Loads FF information via loadFFData call.
-        */
-      bool connectDB() override;
 
       int ffID;                   //!< ID of the force field in DB.
       std::string ffName;         //!< Name of the force field
@@ -94,6 +90,12 @@ namespace tpp {
     public:
       DbInfo(const Settings& set, const std::string& ffn);
 
+      /** \brief Overriden method of DB connection.
+        *
+        * Loads FF information via loadFFData call.
+        */
+      bool connectDB() override;
+      
       int getFFID() { return ffID; }                    //!< Public alias to ffID
       std::string getFFInclude() { return ffInclude; }  //!< Public alias to ffInclude [DEPRECATED]
       std::string getFFRev() { return ffRev; }          //!< Public alias to ffRev

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,10 +5,10 @@ if DEBUGMODE
 AM_CFLAGS = -g3 -O0 -DDEBUG
 AM_CXXFLAGS = -g3 -O0 -DDEBUG
 else
-AM_CFLAGS = -O3 -DNDEBUG
-AM_CXXFLAGS = -O3 -DNDEBUG
+AM_CFLAGS = -O3 -fno-omit-frame-pointer
+AM_CXXFLAGS = -O3 -fno-omit-frame-pointer
 endif
-AM_CXXFLAGS += -std=c++11 -fpermissive
+AM_CXXFLAGS += -std=c++14 -fpermissive
 
 bin_PROGRAMS = programs/tpprenum programs/tppmktop
 MODULES = strutil.cpp structio.cpp tppnames.cpp exceptions.cpp logger.cpp bond_matrix.cpp core.cpp process_options.cpp

--- a/src/atom_definer.cpp
+++ b/src/atom_definer.cpp
@@ -645,8 +645,6 @@ namespace tpp {
     cout << endl;
     TPPI << "== Starting AtomDefiner ==";
     checkAtomlistConsistency();
-    connectDB();
-    scoresZeroFill();
   }
 
   /// crucial internal check
@@ -723,6 +721,8 @@ namespace tpp {
       throw e;
     }
     qu.reset();
+    TPPD << "Setting zero to all scores.";
+    scoresZeroFill();
 
     return true;
   } // connectDB

--- a/src/bond_definer.cpp
+++ b/src/bond_definer.cpp
@@ -40,7 +40,6 @@ namespace tpp {
     cout << endl;
     TPPI << "== Starting BondDefiner ==";
     cout << endl;
-    connectDB();
   }
 
   BondDefiner::~BondDefiner() {

--- a/src/db_base.cpp
+++ b/src/db_base.cpp
@@ -27,7 +27,7 @@ namespace tpp {
    */
   DbBase::DbBase(const Settings& set) :
        settings(set), con(new mysqlpp::Connection(false)) {
-
+    ;
   }
 
   DbBase::~DbBase(){
@@ -64,7 +64,7 @@ namespace tpp {
     mysqlpp::Row row;
     ostringstream os,os2;
 
-    os << "Checking DB version." << endl;
+    TPPD << "Checking DB version." << endl;
     os2 << "SELECT `id`,`keyword`,`value` FROM `properties` WHERE keyword='magic_number'";
     #ifdef SQLDEBUG
     TPPD << os2.str();
@@ -113,7 +113,7 @@ namespace tpp {
     * \brief DB INFO implementation
     */
   DbInfo::DbInfo(const Settings& sets, const std::string& ffn): DbBase(sets), ffName(ffn) {
-    this->connectDB();
+    ;
   }
 
   /**
@@ -122,6 +122,7 @@ namespace tpp {
   bool DbInfo::connectDB() {
     DbBase::connectDB();
     this->loadFFData();
+    return true;
   }
 
   /** \brief Load FF data from DB and set up object variables


### PR DESCRIPTION
Program had segfault in -O1 og higher gcc optimization modes.

Here I moved object handling with unique_ptr, switch standard to c++14, remove connectDB virtual method from contructors.